### PR TITLE
Fix warning in python 3.8

### DIFF
--- a/UnseenMail.py
+++ b/UnseenMail.py
@@ -38,7 +38,7 @@ def check_gmail(gmail_account):
 
 for account in accounts:
     currentAccount = accounts[account]
-    if account is "DEFAULT":
+    if account == "DEFAULT":
         continue
     if not currentAccount["icon"]:
         icon = accounts["DEFAULT"]["icon"]


### PR DESCRIPTION
The warning line:
```
UnseenMail.py:66: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if account is "DEFAULT":
```