### PR TITLE
add folder to imap

### DIFF
--- a/UnseenMail.py
+++ b/UnseenMail.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from __future__ import print_function
 from apiclient.discovery import build
 from httplib2 import Http
@@ -19,7 +20,10 @@ def check_imap(imap_account):
     else:
         client = imaplib.IMAP4(imap_account["host"], int(imap_account["port"]))
     client.login(imap_account["login"], imap_account["password"])
-    client.select()
+    if "folder" in imap_account:
+        client.select(imap_account["folder"])
+    else:
+        client.select()
     return len(client.search(None, 'UNSEEN')[1][0].split())
 
 

--- a/accounts.ini
+++ b/accounts.ini
@@ -6,6 +6,7 @@
 #useSSL = true
 #login = email
 #password = password
+#folder = INBOX/subfolder
 #icon=
 
 [DEFAULT]


### PR DESCRIPTION
Hi,
I have some mail filters running that automatically sort mails into specific folders. I looked for a method to show how many new mails are in a specific folder and didn't find one.

This PR adds an optional config parameter "folder". If set, the script looks for new mails in this specific folder instead of the normal INBOX.

Best
Daniel