### PR TITLE
Use RawConfigParser instead of ConfigParser

### DIFF
--- a/UnseenMail.py
+++ b/UnseenMail.py
@@ -9,7 +9,7 @@ import os
 import configparser
 
 dirname = os.path.split(os.path.abspath(__file__))[0]
-accounts = configparser.ConfigParser()
+accounts = configparser.RawConfigParser()
 accounts.read(os.path.abspath(dirname + '/accounts.ini'))
 strFormatted = ""
 


### PR DESCRIPTION
(Safe)ConfigParser throws an error on various symbols that aren't exactly unlikely to be part of a password.